### PR TITLE
Refactor useFileExplorer and usePlayground hooks to improve file mana…

### DIFF
--- a/features/playground/hooks/useFileExplorer.tsx
+++ b/features/playground/hooks/useFileExplorer.tsx
@@ -71,7 +71,7 @@ interface FileExplorerState {
   saveAllFiles: (saveTemplateData: (data: TemplateFolder) => Promise<void>) => Promise<void>;
 }
 
-//@ts-ignore
+
 export const useFileExplorer= create<FileExplorerState>((set, get) => ({
   templateData: null,
   playgroundId: '',
@@ -132,6 +132,15 @@ export const useFileExplorer= create<FileExplorerState>((set, get) => ({
             editorContent: newEditorContent
         });
     },
+
+    closeAllFiles: () => {
+        set({
+            openFiles: [],
+            activeFileId: null,
+            editorContent: ''
+        });
+    },
+
       handleAddFile: async (newFile, parentPath, writeFileSync, instance, saveTemplateData) => {
     const { templateData } = get();
     if (!templateData) return;

--- a/features/playground/hooks/usePlayground.tsx
+++ b/features/playground/hooks/usePlayground.tsx
@@ -42,8 +42,8 @@ export const usePlayground = (id: string): UsePlaygroundReturn => {
       setError(null);
 
       const data = await getPlaygroundById(id);
-    //   @ts-ignore
-      setPlaygroundData(data);
+    
+      setPlaygroundData(data ? { ...data, id } : null);
 
       const rawContent = data?.templateFiles?.[0]?.content;
       


### PR DESCRIPTION
This pull request introduces improvements to the state management and data handling in the playground feature, focusing on file explorer functionality and playground data initialization. The most important changes are grouped below by theme.

**File Explorer State Management:**

* Added a new `closeAllFiles` method to the `useFileExplorer` store, which clears the list of open files, resets the active file ID, and empties the editor content. This provides a convenient way to close all files at once.

**TypeScript Cleanup:**

* Removed a `//@ts-ignore` directive from the `useFileExplorer` store initialization, indicating improved type safety or resolved type issues.

**Playground Data Handling:**

* Updated the `usePlayground` hook to set `playgroundData` with the correct `id` property when data is available, or to `null` if not. This ensures consistent and reliable initialization of playground state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to close all open files simultaneously in the file explorer, resetting the editor and file state.

* **Bug Fixes**
  * Improved playground data handling to ensure proper data structure and integrity during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->