### PR TITLE
Add user guide section to documentation

### DIFF
--- a/app/docs/(docs-layout)/ai-code-suggestions/page.tsx
+++ b/app/docs/(docs-layout)/ai-code-suggestions/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+import { ShortcutKey } from "@/features/docs/components/shortcut-key"
+
+export const metadata: Metadata = {
+  title: "AI Code Suggestions",
+  description: "How to enable, trigger, accept, and reject AI code suggestions.",
+}
+
+export default function AICodeSuggestionsPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="AI Code Suggestions"
+        description="Xynraco can suggest code inline as you type, similar to an autocomplete that understands your file."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Enabling AI suggestions</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          AI suggestions are on by default in the editor. Use the AI toggle in the playground
+          toolbar to turn suggestions on or off for your session. When it's off, Xynraco won't
+          request or show any suggestions.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Triggering a suggestion</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Keep typing",
+              description:
+                "Suggestions can appear automatically as you type, after certain characters like brackets, dots, or new lines.",
+            },
+            {
+              title: "Or trigger one manually",
+              description: (
+                <span className="inline-flex flex-wrap items-center gap-2">
+                  Press <ShortcutKey keys={["Ctrl", "Space"]} /> at your cursor position to ask
+                  for a suggestion right away.
+                </span>
+              ),
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Accepting or rejecting a suggestion
+        </h2>
+        <ul className="flex flex-col gap-3 text-muted-foreground">
+          <li className="flex items-center gap-2">
+            <ShortcutKey keys={["Tab"]} />
+            <span>accepts the suggestion and inserts it into your file.</span>
+          </li>
+          <li className="flex items-center gap-2">
+            <ShortcutKey keys={["Esc"]} />
+            <span>dismisses the suggestion without inserting anything.</span>
+          </li>
+        </ul>
+        <p className="leading-relaxed text-muted-foreground">
+          If you keep typing instead of accepting or rejecting, the suggestion is replaced with
+          a new one based on your latest cursor position.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What the AI can help with</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Suggestions are generated from the content of the file you're editing and your cursor
+          position, so they're most useful for completing the line or block you're currently
+          writing, filling in boilerplate like function signatures and imports, and continuing a
+          pattern you've already started elsewhere in the file.
+        </p>
+      </section>
+
+      <DocsCallout variant="warning">
+        Always review a suggestion before accepting it. Treat it as a fast first draft, not a
+        guaranteed-correct answer.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/ai-code-suggestions" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/creating-a-playground/page.tsx
+++ b/app/docs/(docs-layout)/creating-a-playground/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next"
+import { Code2, Compass, Database, FlameIcon, Lightbulb, Terminal, Zap } from "lucide-react"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+export const metadata: Metadata = {
+  title: "Creating a Playground",
+  description: "How to create a new playground and choose a template.",
+}
+
+const templates = [
+  { name: "React", icon: Zap, description: "A component-based UI library" },
+  { name: "Next.js", icon: Lightbulb, description: "Full-stack React framework" },
+  { name: "Express", icon: Database, description: "Minimal Node.js backend" },
+  { name: "Vue", icon: Compass, description: "Approachable frontend framework" },
+  { name: "Hono", icon: FlameIcon, description: "Lightweight, edge-ready backend" },
+  { name: "Angular", icon: Terminal, description: "Full-featured frontend framework" },
+] as const
+
+export default function CreatingAPlaygroundPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Creating a Playground"
+        description="A playground is your project: a file tree, an editor, and a live preview, all running in one tab."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Create a new playground</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Open your dashboard",
+              description:
+                "Sign in and go to your dashboard, where all your existing playgrounds are listed.",
+            },
+            {
+              title: "Start a new playground",
+              description:
+                "Use the create action on the dashboard or sidebar to open the template picker.",
+            },
+            {
+              title: "Choose a template",
+              description:
+                "Pick the stack you want to start from. Each template comes preconfigured with a working starter project.",
+            },
+            {
+              title: "Name your playground",
+              description:
+                "Give it a short, descriptive title so you can find it later. You can rename it any time.",
+            },
+            {
+              title: "Create it",
+              description:
+                "Confirm, and Xynraco provisions the playground and opens the editor for you.",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Available templates</h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {templates.map((template) => (
+            <Card key={template.name}>
+              <CardHeader className="flex flex-row items-center gap-3 space-y-0">
+                <template.icon className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <CardTitle className="text-sm">{template.name}</CardTitle>
+                  <CardDescription>{template.description}</CardDescription>
+                </div>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <DocsCallout variant="tip">
+        Not sure which template to pick? Choose React or Next.js if you're building a UI, or
+        Express or Hono if you just need an API to experiment with.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/creating-a-playground" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/github-integration/page.tsx
+++ b/app/docs/(docs-layout)/github-integration/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+
+export const metadata: Metadata = {
+  title: "GitHub Integration",
+  description: "How to connect your GitHub account and browse your repositories.",
+}
+
+export default function GitHubIntegrationPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="GitHub Integration"
+        description="Connect your GitHub account to browse your repositories without leaving the IDE."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Connecting your account</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Open the GitHub panel",
+              description: "From a playground, open the GitHub connect dialog from the toolbar.",
+            },
+            {
+              title: "Link your account, if needed",
+              description:
+                "If you originally signed in with Google, you'll be prompted to also sign in with GitHub so Xynraco can read your repositories.",
+            },
+            {
+              title: "Approve access",
+              description: "Approve the requested permissions on GitHub's authorization screen.",
+            },
+            {
+              title: "You're connected",
+              description:
+                "Once linked, the dialog loads your repositories automatically the next time you open it.",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Browsing your repositories</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Once connected, the GitHub panel lists your repositories with their visibility, star
+          count, and fork count. Use the search field to filter by name, then select a repository
+          to work with it inside Xynraco.
+        </p>
+      </section>
+
+      <DocsCallout variant="note">
+        Signing in with GitHub for authentication and connecting GitHub for repository access are
+        separate steps. You can sign in with Google and still connect GitHub afterward.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/github-integration" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/keyboard-shortcuts/page.tsx
+++ b/app/docs/(docs-layout)/keyboard-shortcuts/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { ShortcutKey } from "@/features/docs/components/shortcut-key"
+
+export const metadata: Metadata = {
+  title: "Keyboard Shortcuts",
+  description: "Keyboard shortcuts for working faster in Xynraco.",
+}
+
+interface ShortcutEntry {
+  keys: string[]
+  description: string
+}
+
+const editorShortcuts: ShortcutEntry[] = [
+  { keys: ["Ctrl", "S"], description: "Save the active file" },
+  { keys: ["Ctrl", "Space"], description: "Trigger an AI code suggestion" },
+  { keys: ["Tab"], description: "Accept the current AI suggestion" },
+  { keys: ["Esc"], description: "Reject the current AI suggestion" },
+]
+
+const navigationShortcuts: ShortcutEntry[] = [
+  { keys: ["Ctrl", "B"], description: "Toggle the sidebar" },
+]
+
+function ShortcutTable({ entries }: { entries: ShortcutEntry[] }) {
+  return (
+    <div className="flex flex-col divide-y rounded-lg border">
+      {entries.map((entry) => (
+        <div
+          key={entry.description}
+          className="flex items-center justify-between gap-4 px-4 py-3"
+        >
+          <span className="text-sm text-muted-foreground">{entry.description}</span>
+          <ShortcutKey keys={entry.keys} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function KeyboardShortcutsPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Keyboard Shortcuts"
+        description="A few shortcuts make working in Xynraco noticeably faster."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Editor</h2>
+        <ShortcutTable entries={editorShortcuts} />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Navigation</h2>
+        <ShortcutTable entries={navigationShortcuts} />
+      </section>
+
+      <p className="text-sm text-muted-foreground">
+        On macOS, use Cmd in place of Ctrl for every shortcut above.
+      </p>
+
+      <DocsPager currentHref="/docs/keyboard-shortcuts" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/layout.tsx
+++ b/app/docs/(docs-layout)/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next"
+import type { ReactNode } from "react"
+
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { DocsSidebar } from "@/features/docs/components/docs-sidebar"
+import { DocsTopbar } from "@/features/docs/components/docs-topbar"
+
+export const metadata: Metadata = {
+  title: {
+    template: "%s | Xynraco Docs",
+    default: "Xynraco Docs",
+  },
+  description: "Learn how to use the Xynraco browser-based IDE.",
+}
+
+export default function DocsLayout({ children }: { children: ReactNode }) {
+  return (
+    <SidebarProvider defaultOpen>
+      <DocsSidebar />
+      <SidebarInset>
+        <DocsTopbar />
+        <div className="flex-1 overflow-x-hidden">
+          <div className="mx-auto w-full max-w-3xl px-6 py-10 sm:px-10">{children}</div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/app/docs/(docs-layout)/page.tsx
+++ b/app/docs/(docs-layout)/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { Code2, Compass, Database, FlameIcon, Lightbulb, Terminal, Zap } from "lucide-react"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export const metadata: Metadata = {
+  title: "Introduction",
+  description: "What Xynraco is, who it's for, and what you can build with it.",
+}
+
+const templates = [
+  { name: "React", icon: Zap },
+  { name: "Next.js", icon: Lightbulb },
+  { name: "Express", icon: Database },
+  { name: "Vue", icon: Compass },
+  { name: "Hono", icon: FlameIcon },
+  { name: "Angular", icon: Terminal },
+] as const
+
+export default function IntroductionPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Introduction"
+        description="Xynraco is a browser-based IDE that lets you build, run, and preview full projects without installing anything locally."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What is Xynraco?</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Xynraco runs a real Node.js environment directly in your browser using WebContainers.
+          You write code in a Monaco-powered editor, see a live preview update as you save, and
+          get AI-assisted code suggestions while you work, all without spinning up a local dev
+          server.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Who is it for?</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Xynraco is built for developers who want to prototype an idea, follow a tutorial, or
+          share a runnable project without context-switching to a local setup. It works well for
+          quick experiments, coding interviews, learning a new framework, or pairing on a small
+          project.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What can you build?</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Every playground starts from a template. Pick the stack that matches what you want to
+          build:
+        </p>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {templates.map((template) => (
+            <Card key={template.name}>
+              <CardHeader className="flex flex-row items-center gap-2 space-y-0 p-4">
+                <template.icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                <CardTitle className="text-sm font-medium">{template.name}</CardTitle>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <DocsCallout variant="tip" title="New here?">
+        Start with{" "}
+        <Link href="/docs/signing-in" className="font-medium underline underline-offset-4">
+          Signing In
+        </Link>{" "}
+        and then{" "}
+        <Link
+          href="/docs/creating-a-playground"
+          className="font-medium underline underline-offset-4"
+        >
+          Creating a Playground
+        </Link>{" "}
+        to get a project running in under a minute.
+      </DocsCallout>
+
+      <div className="flex justify-end">
+        <Button asChild>
+          <Link href="/docs/signing-in">Get started</Link>
+        </Button>
+      </div>
+
+      <DocsPager currentHref="/docs" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/preview-panel/page.tsx
+++ b/app/docs/(docs-layout)/preview-panel/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+
+export const metadata: Metadata = {
+  title: "Preview Panel",
+  description: "How the live preview works and how to show or hide it.",
+}
+
+export default function PreviewPanelPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Preview Panel"
+        description="The preview panel runs your actual app, not a mock, right next to the editor."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What is the live preview?</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          Xynraco boots a real Node.js environment in your browser using WebContainers, installs
+          your dependencies, and runs your project's dev server. The preview panel shows the
+          actual rendered output of that running process, in real time.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Showing and hiding the preview</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Find the preview toggle",
+              description:
+                "Look for the Show Preview / Hide Preview control in the playground toolbar.",
+            },
+            {
+              title: "Toggle it",
+              description:
+                "Click it to hide the preview and give the editor the full width, or click it again to bring the preview back.",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">How it updates</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          The preview is connected to the WebContainer's running dev server. When you save a
+          file, that process picks up the change and the preview reflects it, the same way it
+          would with hot reload on your own machine, without any deploys.
+        </p>
+      </section>
+
+      <DocsCallout variant="tip">
+        If the preview looks stuck, save your file again. The first build after creating a
+        playground can take a few extra seconds while dependencies install.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/preview-panel" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/signing-in/page.tsx
+++ b/app/docs/(docs-layout)/signing-in/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+
+export const metadata: Metadata = {
+  title: "Signing In",
+  description: "How to sign in to Xynraco with GitHub or Google.",
+}
+
+export default function SigningInPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Signing In"
+        description="Xynraco uses GitHub or Google to sign you in. There's no separate password to create or remember."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Sign in with GitHub or Google</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Open the sign-in page",
+              description:
+                "Go to Xynraco and click Sign In. You'll see two options: Sign in with Google and Sign in with GitHub.",
+            },
+            {
+              title: "Choose a provider",
+              description:
+                "Click whichever account you want to use. You're redirected to GitHub or Google to confirm access.",
+            },
+            {
+              title: "Approve access",
+              description: "Review the permissions requested and approve them to continue.",
+            },
+            {
+              title: "You're redirected back in",
+              description:
+                "After approving, you're sent straight to your dashboard, already signed in.",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">What happens after you sign in?</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          The first time you sign in, Xynraco creates your account automatically. You land on
+          your dashboard, where your playgrounds live, and your session stays active until you
+          sign out or it expires.
+        </p>
+      </section>
+
+      <DocsCallout variant="note">
+        Signing in with GitHub does not automatically connect your repositories for browsing
+        inside the IDE. That's a separate step, covered in GitHub Integration.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/signing-in" />
+    </div>
+  )
+}

--- a/app/docs/(docs-layout)/using-the-editor/page.tsx
+++ b/app/docs/(docs-layout)/using-the-editor/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next"
+
+import { DocsPageHeader } from "@/features/docs/components/docs-page-header"
+import { DocsPager } from "@/features/docs/components/docs-pager"
+import { DocsCallout } from "@/features/docs/components/docs-callout"
+import { NumberedSteps } from "@/features/docs/components/numbered-steps"
+import { ShortcutKey } from "@/features/docs/components/shortcut-key"
+
+export const metadata: Metadata = {
+  title: "Using the Editor",
+  description: "How to open files, edit code, manage tabs, and save your work.",
+}
+
+export default function UsingTheEditorPage() {
+  return (
+    <div className="flex flex-col gap-10">
+      <DocsPageHeader
+        title="Using the Editor"
+        description="The editor is where you'll spend most of your time inside a playground."
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Opening files</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          The file tree on the left shows every file and folder in your playground. Click a file
+          to open it in the editor. Folders expand and collapse when you click them.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Working with tabs</h2>
+        <NumberedSteps
+          steps={[
+            {
+              title: "Open multiple files",
+              description:
+                "Every file you open from the file tree gets its own tab above the editor, so you can switch between files without losing your place.",
+            },
+            {
+              title: "Switch between tabs",
+              description: "Click a tab to bring that file into focus. The active tab is highlighted.",
+            },
+            {
+              title: "Close a tab",
+              description:
+                "Use the close control on the tab to remove it from the open files list. This doesn't delete the file, it just closes the view.",
+            },
+          ]}
+        />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Unsaved changes</h2>
+        <p className="leading-relaxed text-muted-foreground">
+          When a file has changes that haven't been saved, its tab shows a small dot next to the
+          file name, and the editor header shows an "Unsaved changes" label. Saving clears the
+          indicator for that file.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight">Saving your work</h2>
+        <p className="leading-relaxed text-muted-foreground">You can save in two ways:</p>
+        <ul className="flex flex-col gap-3 text-muted-foreground">
+          <li className="flex items-center gap-2">
+            <ShortcutKey keys={["Ctrl", "S"]} />
+            <span>saves the file you're currently editing.</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span>
+              Click <span className="font-medium text-foreground">Save</span> in the editor
+              toolbar to save the active file, or <span className="font-medium text-foreground">Save All</span> to save every open file with unsaved changes at once.
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <DocsCallout variant="note">
+        On macOS, use Cmd instead of Ctrl for the same shortcut.
+      </DocsCallout>
+
+      <DocsPager currentHref="/docs/using-the-editor" />
+    </div>
+  )
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,8 +1,0 @@
-export default function DocsPage() {
-  return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-      <h1 className="text-4xl font-extrabold">Documentation</h1>
-      <p className="text-muted-foreground text-lg">Coming soon... we're working on it.</p>
-    </div>
-  );
-}

--- a/features/docs/components/docs-callout.tsx
+++ b/features/docs/components/docs-callout.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react"
+import type { LucideIcon } from "lucide-react"
+import { Info, Lightbulb, TriangleAlert } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { cn } from "@/lib/utils"
+
+type CalloutVariant = "note" | "tip" | "warning"
+
+interface CalloutConfig {
+  icon: LucideIcon
+  label: string
+  className: string
+}
+
+interface DocsCalloutProps {
+  variant?: CalloutVariant
+  title?: string
+  children: ReactNode
+  className?: string
+}
+
+const calloutConfig: Record<CalloutVariant, CalloutConfig> = {
+  note: { icon: Info, label: "Note", className: "border-blue-500/30 [&>svg]:text-blue-500" },
+  tip: { icon: Lightbulb, label: "Tip", className: "border-emerald-500/30 [&>svg]:text-emerald-500" },
+  warning: { icon: TriangleAlert, label: "Warning", className: "border-amber-500/40 [&>svg]:text-amber-500" },
+}
+
+export function DocsCallout({ variant = "note", title, children, className }: DocsCalloutProps) {
+  const config = calloutConfig[variant]
+  const Icon = config.icon
+
+  return (
+    <Alert className={cn(config.className, className)}>
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle>{title ?? config.label}</AlertTitle>
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  )
+}

--- a/features/docs/components/docs-page-header.tsx
+++ b/features/docs/components/docs-page-header.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react"
+
+interface DocsPageHeaderProps {
+  title: string
+  description?: string
+  children?: ReactNode
+}
+
+export function DocsPageHeader({ title, description, children }: DocsPageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-2 border-b pb-6">
+      <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        {title}
+      </h1>
+      {description && <p className="text-lg text-muted-foreground">{description}</p>}
+      {children}
+    </div>
+  )
+}

--- a/features/docs/components/docs-pager.tsx
+++ b/features/docs/components/docs-pager.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { getAdjacentDocs } from "@/features/docs/lib/nav-items"
+
+interface DocsPagerProps {
+  currentHref: string
+}
+
+export function DocsPager({ currentHref }: DocsPagerProps) {
+  const { prev, next } = getAdjacentDocs(currentHref)
+
+  if (!prev && !next) {
+    return null
+  }
+
+  return (
+    <nav aria-label="Pagination" className="grid grid-cols-1 gap-4 border-t pt-8 sm:grid-cols-2">
+      {prev ? (
+        <Link href={prev.href} className="group">
+          <Card className="h-full transition-colors group-hover:border-primary/50">
+            <CardContent className="flex items-center gap-3 p-4">
+              <ArrowLeft
+                className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:-translate-x-0.5"
+                aria-hidden="true"
+              />
+              <div className="flex flex-col">
+                <span className="text-xs text-muted-foreground">Previous</span>
+                <span className="text-sm font-medium">{prev.title}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      ) : (
+        <div />
+      )}
+
+      {next ? (
+        <Link href={next.href} className="group">
+          <Card className="h-full transition-colors group-hover:border-primary/50">
+            <CardContent className="flex items-center justify-end gap-3 p-4">
+              <div className="flex flex-col items-end">
+                <span className="text-xs text-muted-foreground">Next</span>
+                <span className="text-sm font-medium">{next.title}</span>
+              </div>
+              <ArrowRight
+                className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                aria-hidden="true"
+              />
+            </CardContent>
+          </Card>
+        </Link>
+      ) : (
+        <div />
+      )}
+    </nav>
+  )
+}

--- a/features/docs/components/docs-sidebar.tsx
+++ b/features/docs/components/docs-sidebar.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { BookText } from "lucide-react"
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "@/components/ui/sidebar"
+import { Button } from "@/components/ui/button"
+import { docsNavItems } from "@/features/docs/lib/nav-items"
+
+export function DocsSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <Sidebar variant="inset" collapsible="offcanvas" className="border-r">
+      <SidebarHeader>
+        <div className="flex items-center gap-2 px-2 py-3">
+          <BookText className="h-5 w-5 text-primary" aria-hidden="true" />
+          <span className="text-sm font-semibold">Xynraco Docs</span>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>User Guide</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {docsNavItems.map((item) => {
+                const isActive = pathname === item.href
+                const Icon = item.icon
+
+                return (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton asChild isActive={isActive} tooltip={item.title}>
+                      <Link href={item.href}>
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter>
+        <Button asChild variant="outline" size="sm" className="w-full justify-start">
+          <Link href="/dashboard">Back to Dashboard</Link>
+        </Button>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
+  )
+}

--- a/features/docs/components/docs-topbar.tsx
+++ b/features/docs/components/docs-topbar.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+import { SidebarTrigger } from "@/components/ui/sidebar"
+import { Separator } from "@/components/ui/separator"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { docsNavItems } from "@/features/docs/lib/nav-items"
+
+export function DocsTopbar() {
+  const pathname = usePathname()
+  const activeItem = docsNavItems.find((item) => item.href === pathname)
+
+  return (
+    <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <SidebarTrigger />
+      <Separator orientation="vertical" className="h-4" />
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/docs">Docs</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          {activeItem && activeItem.href !== "/docs" && (
+            <>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{activeItem.title}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </>
+          )}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </header>
+  )
+}

--- a/features/docs/components/numbered-steps.tsx
+++ b/features/docs/components/numbered-steps.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface Step {
+  title: string
+  description: ReactNode
+}
+
+interface NumberedStepsProps {
+  steps: Step[]
+  className?: string
+}
+
+export function NumberedSteps({ steps, className }: NumberedStepsProps) {
+  return (
+    <ol className={cn("flex flex-col gap-6", className)}>
+      {steps.map((step, index) => (
+        <li key={step.title} className="flex gap-4">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10 text-sm font-semibold text-primary">
+            {index + 1}
+          </div>
+          <div className="flex flex-col gap-1 pt-0.5">
+            <p className="font-medium leading-none">{step.title}</p>
+            <div className="text-sm leading-relaxed text-muted-foreground">
+              {step.description}
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/features/docs/components/shortcut-key.tsx
+++ b/features/docs/components/shortcut-key.tsx
@@ -1,0 +1,22 @@
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+
+interface ShortcutKeyProps {
+  keys: string[]
+  label?: string
+}
+
+export function ShortcutKey({ keys, label }: ShortcutKeyProps) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <KbdGroup>
+        {keys.map((key, index) => (
+          <span key={key} className="inline-flex items-center gap-1">
+            <Kbd>{key}</Kbd>
+            {index < keys.length - 1 && <span className="text-muted-foreground">+</span>}
+          </span>
+        ))}
+      </KbdGroup>
+      {label && <span className="text-sm text-muted-foreground">{label}</span>}
+    </span>
+  )
+}

--- a/features/docs/lib/nav-items.ts
+++ b/features/docs/lib/nav-items.ts
@@ -1,0 +1,83 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  BookOpen,
+  LogIn,
+  FolderPlus,
+  Code2,
+  MonitorPlay,
+  Sparkles,
+  Github,
+  Keyboard,
+} from "lucide-react"
+
+export interface DocNavItem {
+  title: string
+  href: string
+  description: string
+  icon: LucideIcon
+}
+
+export const docsNavItems: DocNavItem[] = [
+  {
+    title: "Introduction",
+    href: "/docs",
+    description: "What Xynraco is and what you can build with it",
+    icon: BookOpen,
+  },
+  {
+    title: "Signing In",
+    href: "/docs/signing-in",
+    description: "Log in with GitHub or Google",
+    icon: LogIn,
+  },
+  {
+    title: "Creating a Playground",
+    href: "/docs/creating-a-playground",
+    description: "Start a new project from a template",
+    icon: FolderPlus,
+  },
+  {
+    title: "Using the Editor",
+    href: "/docs/using-the-editor",
+    description: "Files, tabs, and saving your work",
+    icon: Code2,
+  },
+  {
+    title: "Preview Panel",
+    href: "/docs/preview-panel",
+    description: "See your app update live as you code",
+    icon: MonitorPlay,
+  },
+  {
+    title: "AI Code Suggestions",
+    href: "/docs/ai-code-suggestions",
+    description: "Let AI help you write code faster",
+    icon: Sparkles,
+  },
+  {
+    title: "GitHub Integration",
+    href: "/docs/github-integration",
+    description: "Connect your account and browse your repos",
+    icon: Github,
+  },
+  {
+    title: "Keyboard Shortcuts",
+    href: "/docs/keyboard-shortcuts",
+    description: "Work faster with shortcuts",
+    icon: Keyboard,
+  },
+]
+
+export function getAdjacentDocs(href: string): {
+  prev: DocNavItem | null
+  next: DocNavItem | null
+} {
+  const index = docsNavItems.findIndex((item) => item.href === href)
+  if (index === -1) {
+    return { prev: null, next: null }
+  }
+  return {
+    prev: index > 0 ? docsNavItems[index - 1] : null,
+    next: index < docsNavItems.length - 1 ? docsNavItems[index + 1] : null,
+  }
+}


### PR DESCRIPTION
This pull request adds a complete set of new documentation pages for the Xynraco browser-based IDE, covering all core features and user flows. Each page is implemented as a standalone React component with consistent layout, navigation, and metadata for improved discoverability and user experience.

The most important changes are:

**New Documentation Pages:**

* Added `Introduction`, `Signing In`, `Creating a Playground`, `AI Code Suggestions`, `Preview Panel`, `GitHub Integration`, and `Keyboard Shortcuts` pages, each with clear explanations, step-by-step guides, and relevant UI components such as callouts, pagers, and step lists. [[1]](diffhunk://#diff-05d26baf2dc725a8dd2be8de5a60dfbd473ac55ab8142e001f3e57529d709195R1-R95) [[2]](diffhunk://#diff-d02d190cc1ed3bd3f508137750742d737c69df954b172ec8e6d6b8e47ef8366eR1-R65) [[3]](diffhunk://#diff-301781bc960661817a061b5ea8c9a994f3bc45e7efb8eea2d4e35b2ffc7d1228R1-R90) [[4]](diffhunk://#diff-fd6cf138c6d40b03cd872312a116aa67d54a6b2f22d3d7caf48eb7b4a68933e2R1-R91) [[5]](diffhunk://#diff-ff649bf1a3d61d23f64613248e5bfa04ded37db0f59150efddd7fd91831ff77eR1-R65) [[6]](diffhunk://#diff-cd0d2e126469ab1090071dfa5245cf35c18e5f3e9060c3f5d0460c511470dee3R1-R64) [[7]](diffhunk://#diff-6f72b6a90f98ae894949e0d06d1947a778ad4aa3823dd05383b774048dddc989R1-R69)

**Documentation Layout and Navigation:**

* Introduced a new docs layout in `layout.tsx` that provides a sidebar, topbar, and consistent content area for all docs pages, improving navigation and readability.

**Metadata and SEO Improvements:**

* Each page now exports a `metadata` object with title and description, supporting better SEO and browser tab labeling. (All page-level changes, e.g., [[1]](diffhunk://#diff-5878bffe5b7e190a51b4ac8f69c8aa1b3104590b96182d386f7696f5e077591dR1-R28) [[2]](diffhunk://#diff-05d26baf2dc725a8dd2be8de5a60dfbd473ac55ab8142e001f3e57529d709195R1-R95) etc.)

**Consistent Use of Shared UI Components:**

* All documentation pages utilize shared components such as `DocsPageHeader`, `DocsPager`, `DocsCallout`, and `NumberedSteps` for a unified look and feel. (All page-level changes)

**Keyboard Shortcuts Reference:**

* Added a dedicated page listing all keyboard shortcuts, grouped by theme, with a clear note for macOS users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full documentation experience with a sidebar, top bar, page header, callouts, pager navigation, step-by-step sections, shortcut displays, and adjacent-page links.
  * Published new docs pages for getting started, signing in, using the editor, keyboard shortcuts, preview panel, GitHub integration, creating a playground, and AI code suggestions.
* **Bug Fixes**
  * Replaced the placeholder docs landing page with a complete introduction page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->