### PR TITLE
ci: add explicit permissions block to satisfy CodeQL workflow check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,16 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, Dev-Branch]
   push:
-    branches: [main, dev]
+    branches: [main, Dev-Branch]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint-typecheck-build:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to align with branch naming changes and enhances security by specifying permissions. The most important changes are:

Branch configuration updates:
* The workflow now triggers on pushes and pull requests to the `main` and `Dev-Branch` branches instead of `main` and `dev`, reflecting a branch naming update.

Security improvements:
* Added explicit `permissions` to restrict workflow access to read-only for repository contents.