### PR TITLE
Add new API endpoint

### DIFF
--- a/app/api-test/page.tsx
+++ b/app/api-test/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next"
 
 // needs to be completed
-
-//import { ApiTester } from "@/features/api-test/components/api-tester" 
+import { ApiTester } from "@/features/api-test/components/api-tester" 
 
 export const metadata: Metadata = {
   title: "API Tester | Xynraco",
@@ -20,7 +19,7 @@ export default function ApiTestPage() {
           expected.
         </p>
       </div>
-      {/* <ApiTester /> */}
+      <ApiTester /> 
     </div>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import DashboardWithTabs from "@/features/dashboard/components/dashboard-with-ta
 import { ConnectedRepos } from "@/features/dashboard/components/connected-repos";
 import { getConnectedRepositories } from "@/features/dashboard/action/github-actions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import Link from "next/link";
+import { ChevronRight, FlaskConical } from "lucide-react";
 
 const DashboardMainPage = async () => {
   const playgrounds = await getAllPlaygroundForUser();
@@ -14,23 +16,46 @@ const DashboardMainPage = async () => {
   
   return (
     <div className="flex flex-col justify-start items-center min-h-screen w-full px-3 sm:px-4 md:px-6 py-4 sm:py-6 lg:py-10">
-      <div className="w-full max-w-[1200px] flex items-center justify-between mb-4 sm:mb-5">
+      <div className="w-full max-w-300 flex items-center justify-between mb-4 sm:mb-5">
         <div className="flex items-center gap-3">
           <SidebarTrigger className="md:hidden" />
           <h1 className="text-xl sm:text-2xl font-semibold">Dashboard</h1>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 lg:gap-6 w-full max-w-[1200px]">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 lg:gap-6 w-full max-w-300">
         <AddNewButton />
         <AddRepo />
       </div>
 
-      <div className="w-full max-w-[1200px] mt-4 sm:mt-6">
+      <div className="w-full max-w-300 mt-3 sm:mt-4">
+        <Link
+          href="/api-test"
+          className="group flex items-center justify-between gap-4 rounded-lg border border-white/10 bg-linear-to-r from-zinc-950 via-zinc-900 to-slate-900 px-5 py-4 text-left shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition-all duration-300 hover:border-emerald-500/40 hover:shadow-[0_16px_40px_rgba(16,185,129,0.12)]"
+        >
+          <div className="flex items-center gap-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-400 transition-transform duration-300 group-hover:scale-105">
+              <FlaskConical className="h-5 w-5" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-semibold text-white">API Tester</h2>
+                <span className="rounded-full border border-emerald-500/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-emerald-400">
+                  New
+                </span>
+              </div>
+              <p className="text-sm text-zinc-400">Open the new API test workspace from the dashboard.</p>
+            </div>
+          </div>
+          <ChevronRight className="h-5 w-5 text-zinc-500 transition-transform duration-300 group-hover:translate-x-1 group-hover:text-zinc-300" />
+        </Link>
+      </div>
+
+      <div className="w-full max-w-300 mt-4 sm:mt-6">
         <ConnectedRepos repositories={repositories || []} />
       </div>
 
-      <div className="mt-5 sm:mt-7 lg:mt-10 flex flex-col justify-center items-center w-full max-w-[1200px]">
+      <div className="mt-5 sm:mt-7 lg:mt-10 flex flex-col justify-center items-center w-full max-w-300">
         {playgrounds && playgrounds.length === 0 ? (
           <EmptyState title="No projects found" description="Create a new project to get started!" imageSrc='/empty-state.svg'/>
         ) : (

--- a/features/api-test/components/api-tester.tsx
+++ b/features/api-test/components/api-tester.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Loader2, Send } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { BodyEditor } from "@/features/api-test/components/body-editor"
+import { EndpointPicker } from "@/features/api-test/components/endpoint-picker"
+import { HistoryPanel, type HistoryEntry } from "@/features/api-test/components/history-panel"
+import { KeyValueEditor } from "@/features/api-test/components/key-value-editor"
+import { ResponseViewer } from "@/features/api-test/components/response-viewer"
+import { testableEndpoints, type HttpMethod } from "@/features/api-test/lib/endpoints"
+import { sendRequest, type KeyValue, type ResponseResult } from "@/features/api-test/lib/request-runner"
+
+const methodStyles: Record<HttpMethod, string> = {
+  GET: "text-emerald-500 border-emerald-500/30 bg-emerald-500/10",
+  POST: "text-blue-500 border-blue-500/30 bg-blue-500/10",
+  DELETE: "text-red-500 border-red-500/30 bg-red-500/10",
+}
+
+function buildInitialState(endpointId: string) {
+  const endpoint = testableEndpoints.find((e) => e.id === endpointId) ?? testableEndpoints[0]
+  const pathParams: KeyValue[] = (endpoint.params ?? [])
+    .filter((p) => p.location === "path")
+    .map((p) => ({ key: p.name, value: p.placeholder ?? "" }))
+  const queryParams: KeyValue[] = (endpoint.params ?? [])
+    .filter((p) => p.location === "query")
+    .map((p) => ({ key: p.name, value: p.placeholder ?? "" }))
+
+  return {
+    endpoint,
+    pathParams,
+    queryParams,
+    headers: [] as KeyValue[],
+    body: endpoint.sampleBody ?? "",
+  }
+}
+
+export function ApiTester() {
+  const [state, setState] = useState(() => buildInitialState(testableEndpoints[0].id))
+  const [result, setResult] = useState<ResponseResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [history, setHistory] = useState<HistoryEntry[]>([])
+
+  const lockedPathKeys = useMemo(
+    () => (state.endpoint.params ?? []).filter((p) => p.location === "path").map((p) => p.name),
+    [state.endpoint],
+  )
+  const lockedQueryKeys = useMemo(
+    () =>
+      (state.endpoint.params ?? [])
+        .filter((p) => p.location === "query" && p.required)
+        .map((p) => p.name),
+    [state.endpoint],
+  )
+
+  const bodyDisabled = state.endpoint.method === "GET" || state.endpoint.method === "DELETE"
+
+  const selectEndpoint = (id: string) => {
+    setState(buildInitialState(id))
+    setResult(null)
+  }
+
+  const handleSend = async () => {
+    setLoading(true)
+    try {
+      const response = await sendRequest({
+        method: state.endpoint.method,
+        path: state.endpoint.path,
+        pathParams: state.pathParams,
+        queryParams: state.queryParams,
+        headers: state.headers,
+        body: state.body,
+      })
+      setResult(response)
+      setHistory((prev) => [
+        {
+          id: `${Date.now()}`,
+          method: state.endpoint.method,
+          url: response.requestUrl,
+          status: response.status,
+          durationMs: response.durationMs,
+          timestamp: response.timestamp,
+        },
+        ...prev,
+      ].slice(0, 20))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <div className="flex flex-col gap-5">
+        <EndpointPicker selectedId={state.endpoint.id} onSelect={selectEndpoint} />
+
+        <Card>
+          <CardContent className="flex flex-col gap-2 p-4">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className={cn("w-16 justify-center font-mono text-xs", methodStyles[state.endpoint.method])}>
+                {state.endpoint.method}
+              </Badge>
+              <code className="min-w-0 flex-1 truncate font-mono text-sm">{state.endpoint.path}</code>
+            </div>
+          </CardContent>
+        </Card>
+
+        {state.pathParams.length > 0 && (
+          <KeyValueEditor
+            title="Path parameters"
+            rows={state.pathParams}
+            onChange={(rows) => setState((s) => ({ ...s, pathParams: rows }))}
+            lockedKeys={lockedPathKeys}
+          />
+        )}
+
+        <KeyValueEditor
+          title="Query parameters"
+          rows={state.queryParams}
+          onChange={(rows) => setState((s) => ({ ...s, queryParams: rows }))}
+          lockedKeys={lockedQueryKeys}
+        />
+
+        <KeyValueEditor
+          title="Headers"
+          rows={state.headers}
+          onChange={(rows) => setState((s) => ({ ...s, headers: rows }))}
+          keyPlaceholder="Header-Name"
+        />
+
+        <BodyEditor
+          value={state.body}
+          onChange={(body) => setState((s) => ({ ...s, body }))}
+          disabled={bodyDisabled}
+        />
+
+        <Button onClick={handleSend} disabled={loading} className="gap-2 self-start">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          Send request
+        </Button>
+
+        <HistoryPanel
+          entries={history}
+          onClear={() => setHistory([])}
+          onSelect={(entry) => {
+            const match = testableEndpoints.find((e) => e.method === entry.method && entry.url.includes(e.path.split("{")[0]))
+            if (match) selectEndpoint(match.id)
+          }}
+        />
+      </div>
+
+      <div className="lg:sticky lg:top-20 lg:self-start">
+        <ResponseViewer result={result} loading={loading} />
+      </div>
+    </div>
+  )
+}

--- a/features/api-test/components/body-editor.tsx
+++ b/features/api-test/components/body-editor.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useMemo } from "react"
+import { AlertCircle, CheckCircle2 } from "lucide-react"
+
+import { Textarea } from "@/components/ui/textarea"
+
+interface BodyEditorProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+export function BodyEditor({ value, onChange, disabled }: BodyEditorProps) {
+  const validation = useMemo(() => {
+    if (!value.trim()) return { valid: true, message: null as string | null }
+    try {
+      JSON.parse(value)
+      return { valid: true, message: "Valid JSON" }
+    } catch (error) {
+      return { valid: false, message: error instanceof Error ? error.message : "Invalid JSON" }
+    }
+  }, [value])
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">Body</label>
+        {value.trim() && (
+          <span
+            className={`flex items-center gap-1 text-xs ${validation.valid ? "text-emerald-500" : "text-destructive"}`}
+          >
+            {validation.valid ? <CheckCircle2 className="h-3 w-3" /> : <AlertCircle className="h-3 w-3" />}
+            {validation.message}
+          </span>
+        )}
+      </div>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={disabled ? "This method does not send a body." : '{\n  "key": "value"\n}'}
+        className="min-h-[180px] resize-y font-mono text-xs"
+        spellCheck={false}
+      />
+    </div>
+  )
+}

--- a/features/api-test/components/endpoint-picker.tsx
+++ b/features/api-test/components/endpoint-picker.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import { groupEndpoints, testableEndpoints, type HttpMethod } from "@/features/api-test/lib/endpoints"
+
+interface EndpointPickerProps {
+  selectedId: string
+  onSelect: (id: string) => void
+}
+
+const methodStyles: Record<HttpMethod, string> = {
+  GET: "text-emerald-500",
+  POST: "text-blue-500",
+  DELETE: "text-red-500",
+}
+
+export function EndpointPicker({ selectedId, onSelect }: EndpointPickerProps) {
+  const grouped = groupEndpoints()
+  const selected = testableEndpoints.find((endpoint) => endpoint.id === selectedId)
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">Endpoint</label>
+      <Select value={selectedId} onValueChange={onSelect}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Choose an endpoint" />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.entries(grouped).map(([group, endpoints]) => (
+            <SelectGroup key={group}>
+              <SelectLabel>{group}</SelectLabel>
+              {endpoints.map((endpoint) => (
+                <SelectItem key={endpoint.id} value={endpoint.id}>
+                  <span className={cn("font-mono text-xs font-semibold", methodStyles[endpoint.method])}>
+                    {endpoint.method}
+                  </span>{" "}
+                  {endpoint.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          ))}
+        </SelectContent>
+      </Select>
+      {selected?.auth && (
+        <Badge variant="secondary" className="w-fit text-[10px]">
+          Requires a signed-in session
+        </Badge>
+      )}
+    </div>
+  )
+}

--- a/features/api-test/components/history-panel.tsx
+++ b/features/api-test/components/history-panel.tsx
@@ -7,12 +7,12 @@ import { cn } from "@/lib/utils"
 import type { HttpMethod } from "@/features/api-test/lib/endpoints"
 
 export interface HistoryEntry {
-  id        : string
-  method    : HttpMethod | string
-  url       : string
-  status    : number
+  id: string
+  method: HttpMethod | string
+  url: string
+  status: number
   durationMs: number
-  timestamp : string
+  timestamp: string
 }
 
 interface HistoryPanelProps {

--- a/features/api-test/components/key-value-editor.tsx
+++ b/features/api-test/components/key-value-editor.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { Plus, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { KeyValue } from "@/features/api-test/lib/request-runner"
+
+interface KeyValueEditorProps {
+  title: string
+  rows: KeyValue[]
+  onChange: (rows: KeyValue[]) => void
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  lockedKeys?: string[] // keys that cannot be renamed or removed (e.g. required path/query params)
+}
+
+export function KeyValueEditor({
+  title,
+  rows,
+  onChange,
+  keyPlaceholder = "key",
+  valuePlaceholder = "value",
+  lockedKeys = [],
+}: KeyValueEditorProps) {
+  const updateRow = (index: number, field: keyof KeyValue, value: string) => {
+    const next = [...rows]
+    next[index] = { ...next[index], [field]: value }
+    onChange(next)
+  }
+
+  const addRow = () => onChange([...rows, { key: "", value: "" }])
+  const removeRow = (index: number) => onChange(rows.filter((_, i) => i !== index))
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">{title}</label>
+        <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={addRow}>
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {rows.length === 0 && <p className="text-xs text-muted-foreground">None set.</p>}
+
+      <div className="flex flex-col gap-2">
+        {rows.map((row, index) => {
+          const locked = lockedKeys.includes(row.key)
+          return (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                value={row.key}
+                placeholder={keyPlaceholder}
+                disabled={locked}
+                onChange={(e) => updateRow(index, "key", e.target.value)}
+                className="font-mono text-xs"
+              />
+              <Input
+                value={row.value}
+                placeholder={valuePlaceholder}
+                onChange={(e) => updateRow(index, "value", e.target.value)}
+                className="font-mono text-xs"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                onClick={() => removeRow(index)}
+                disabled={locked}
+                aria-label="Remove row"
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/features/dashboard/components/dashboard-sidebar.tsx
+++ b/features/dashboard/components/dashboard-sidebar.tsx
@@ -62,6 +62,7 @@ const lucideIconMap: Record<string, LucideIcon> = {
 
 // Starter template types
 const STARTER_TEMPLATES = ["REACT", "NEXTJS", "EXPRESS", "VUE", "HONO", "ANGULAR"];
+const API_TEST_ROUTE = "/api-test"
 
 export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundData: PlaygroundData[] }) {
   const pathname = usePathname()
@@ -69,6 +70,14 @@ export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundD
   const [isModalOpen, setIsModalOpen] = useState(false)
   
   const recentPlaygrounds = initialPlaygroundData.slice(0, 5) // Show last 5 recent items
+
+  const getPlaygroundHref = (playground: PlaygroundData) => {
+    if (playground.name === "API Prototype" || playground.id === "pg-1") {
+      return API_TEST_ROUTE
+    }
+
+    return `/playground/${playground.id}`
+  }
 
   const handleCreatePlayground = async (data: {
     title: string;
@@ -146,14 +155,15 @@ export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundD
                 <>
                   {recentPlaygrounds.map((playground) => {
                     const IconComponent = lucideIconMap[playground.icon] || Code2;
+                    const href = getPlaygroundHref(playground)
                     return (
                       <SidebarMenuItem key={playground.id}>
                         <SidebarMenuButton
                           asChild
-                          isActive={pathname === `/playground/${playground.id}`}
+                          isActive={pathname === href}
                           tooltip={playground.name}
                         >
-                          <Link href={`/playground/${playground.id}`}>
+                          <Link href={href}>
                             {IconComponent && <IconComponent className="h-4 w-4" />}
                             <span>{playground.name}</span>
                           </Link>


### PR DESCRIPTION
This pull request introduces a new "API Tester" feature and integrates it into the dashboard UI. The main changes include adding a fully functional API testing workspace, updating the dashboard to link to this new feature, and refining the sidebar logic to support the API Tester as a special playground. Below are the most important changes:

**New API Tester Feature:**

* Added a complete `ApiTester` component with support for selecting endpoints, editing parameters, sending requests, viewing responses, and maintaining request history. Supporting components such as `BodyEditor`, `EndpointPicker`, and `KeyValueEditor` were also implemented. (`features/api-test/components/api-tester.tsx` [[1]](diffhunk://#diff-dc8fa39995edf0315e76b628800c3339d03a6eea30f5bf21cc06be2ea506554bR1-R160) `features/api-test/components/body-editor.tsx` [[2]](diffhunk://#diff-b9ccd9f87fa3f65502e9346359cdf5c3dad73b6a8abcfee011294bd12985818cR1-R48) `features/api-test/components/endpoint-picker.tsx` [[3]](diffhunk://#diff-94ce83136ca57b3692948cd7856e7d6ed3cbc79132cf892c87bf2ca28af0e36aR1-R53) `features/api-test/components/key-value-editor.tsx` [[4]](diffhunk://#diff-049a9fdffa61b0cb022690750179fe1d9d3ad042fed029ee07aef9d6e87fe517R1-R81)

**Dashboard Integration:**

* Added a prominent link to the new API Tester workspace on the dashboard main page, styled as a "New" feature and easily accessible to users. (`app/dashboard/page.tsx` [app/dashboard/page.tsxR10-R58](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R10-R58))
* Updated the dashboard sidebar to treat the API Tester as a special playground: if a recent playground is named "API Prototype" or has the id "pg-1", it links to `/api-test` instead of a regular playground route. (`features/dashboard/components/dashboard-sidebar.tsx` [[1]](diffhunk://#diff-5b56f884ca78a7802e2f010aeee8f4042e0b6d720d46298ce36e6dd7e2eb2427R65) [[2]](diffhunk://#diff-5b56f884ca78a7802e2f010aeee8f4042e0b6d720d46298ce36e6dd7e2eb2427R74-R81) [[3]](diffhunk://#diff-5b56f884ca78a7802e2f010aeee8f4042e0b6d720d46298ce36e6dd7e2eb2427R158-R166)

**Page Activation:**

* Enabled the `ApiTester` component on the `/api-test` page, making the feature accessible from the dashboard and sidebar. (`app/api-test/page.tsx` [[1]](diffhunk://#diff-17e16f3d1fe7efede8d8314e59f8c96c2ce2d66d8186920485730870108c12d8L4-R4) [[2]](diffhunk://#diff-17e16f3d1fe7efede8d8314e59f8c96c2ce2d66d8186920485730870108c12d8L23-R22)

These changes collectively provide a user-friendly interface for testing API endpoints directly within the application, improving developer experience and workflow.