### PR TITLE
Implement API history panel and response viewer

### DIFF
--- a/app/api-info/page.tsx
+++ b/app/api-info/page.tsx
@@ -1,8 +1,0 @@
-export default function ApiPage() {
-  return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-      <h1 className="text-4xl font-extrabold">API</h1>
-      <p className="text-muted-foreground text-lg">Coming soon... I am working on it.</p>
-    </div>
-  );
-}

--- a/app/api-test/page.tsx
+++ b/app/api-test/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next"
+
+// needs to be completed
+
+//import { ApiTester } from "@/features/api-test/components/api-tester" 
+
+export const metadata: Metadata = {
+  title: "API Tester | Xynraco",
+  description: "Send real requests to the Xynraco API and inspect the response.",
+}
+
+export default function ApiTestPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10 sm:px-10">
+      <div className="flex flex-col gap-1.5">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">API Tester</h1>
+        <p className="text-muted-foreground">
+          Pick an endpoint, edit the params, headers, or body, and send a real request to your Xynraco
+          deployment. Requests are sent with your current session, so signed-in-only endpoints work as
+          expected.
+        </p>
+      </div>
+      {/* <ApiTester /> */}
+    </div>
+  )
+}

--- a/app/api-test/page.tsx
+++ b/app/api-test/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next"
 
 // needs to be completed
-
-//import { ApiTester } from "@/features/api-test/components/api-tester" 
+import { ApiTester } from "@/features/api-test/components/api-tester" 
 
 export const metadata: Metadata = {
   title: "API Tester | Xynraco",
@@ -20,7 +19,7 @@ export default function ApiTestPage() {
           expected.
         </p>
       </div>
-      {/* <ApiTester /> */}
+      <ApiTester /> 
     </div>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import DashboardWithTabs from "@/features/dashboard/components/dashboard-with-ta
 import { ConnectedRepos } from "@/features/dashboard/components/connected-repos";
 import { getConnectedRepositories } from "@/features/dashboard/action/github-actions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import Link from "next/link";
+import { ChevronRight, FlaskConical } from "lucide-react";
 
 const DashboardMainPage = async () => {
   const playgrounds = await getAllPlaygroundForUser();
@@ -14,23 +16,46 @@ const DashboardMainPage = async () => {
   
   return (
     <div className="flex flex-col justify-start items-center min-h-screen w-full px-3 sm:px-4 md:px-6 py-4 sm:py-6 lg:py-10">
-      <div className="w-full max-w-[1200px] flex items-center justify-between mb-4 sm:mb-5">
+      <div className="w-full max-w-300 flex items-center justify-between mb-4 sm:mb-5">
         <div className="flex items-center gap-3">
           <SidebarTrigger className="md:hidden" />
           <h1 className="text-xl sm:text-2xl font-semibold">Dashboard</h1>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 lg:gap-6 w-full max-w-[1200px]">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 lg:gap-6 w-full max-w-300">
         <AddNewButton />
         <AddRepo />
       </div>
 
-      <div className="w-full max-w-[1200px] mt-4 sm:mt-6">
+      <div className="w-full max-w-300 mt-3 sm:mt-4">
+        <Link
+          href="/api-test"
+          className="group flex items-center justify-between gap-4 rounded-lg border border-white/10 bg-linear-to-r from-zinc-950 via-zinc-900 to-slate-900 px-5 py-4 text-left shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition-all duration-300 hover:border-emerald-500/40 hover:shadow-[0_16px_40px_rgba(16,185,129,0.12)]"
+        >
+          <div className="flex items-center gap-4">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-400 transition-transform duration-300 group-hover:scale-105">
+              <FlaskConical className="h-5 w-5" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-semibold text-white">API Tester</h2>
+                <span className="rounded-full border border-emerald-500/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-emerald-400">
+                  New
+                </span>
+              </div>
+              <p className="text-sm text-zinc-400">Open the new API test workspace from the dashboard.</p>
+            </div>
+          </div>
+          <ChevronRight className="h-5 w-5 text-zinc-500 transition-transform duration-300 group-hover:translate-x-1 group-hover:text-zinc-300" />
+        </Link>
+      </div>
+
+      <div className="w-full max-w-300 mt-4 sm:mt-6">
         <ConnectedRepos repositories={repositories || []} />
       </div>
 
-      <div className="mt-5 sm:mt-7 lg:mt-10 flex flex-col justify-center items-center w-full max-w-[1200px]">
+      <div className="mt-5 sm:mt-7 lg:mt-10 flex flex-col justify-center items-center w-full max-w-300">
         {playgrounds && playgrounds.length === 0 ? (
           <EmptyState title="No projects found" description="Create a new project to get started!" imageSrc='/empty-state.svg'/>
         ) : (

--- a/features/api-test/components/api-tester.tsx
+++ b/features/api-test/components/api-tester.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Loader2, Send } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { BodyEditor } from "@/features/api-test/components/body-editor"
+import { EndpointPicker } from "@/features/api-test/components/endpoint-picker"
+import { HistoryPanel, type HistoryEntry } from "@/features/api-test/components/history-panel"
+import { KeyValueEditor } from "@/features/api-test/components/key-value-editor"
+import { ResponseViewer } from "@/features/api-test/components/response-viewer"
+import { testableEndpoints, type HttpMethod } from "@/features/api-test/lib/endpoints"
+import { sendRequest, type KeyValue, type ResponseResult } from "@/features/api-test/lib/request-runner"
+
+const methodStyles: Record<HttpMethod, string> = {
+  GET: "text-emerald-500 border-emerald-500/30 bg-emerald-500/10",
+  POST: "text-blue-500 border-blue-500/30 bg-blue-500/10",
+  DELETE: "text-red-500 border-red-500/30 bg-red-500/10",
+}
+
+function buildInitialState(endpointId: string) {
+  const endpoint = testableEndpoints.find((e) => e.id === endpointId) ?? testableEndpoints[0]
+  const pathParams: KeyValue[] = (endpoint.params ?? [])
+    .filter((p) => p.location === "path")
+    .map((p) => ({ key: p.name, value: p.placeholder ?? "" }))
+  const queryParams: KeyValue[] = (endpoint.params ?? [])
+    .filter((p) => p.location === "query")
+    .map((p) => ({ key: p.name, value: p.placeholder ?? "" }))
+
+  return {
+    endpoint,
+    pathParams,
+    queryParams,
+    headers: [] as KeyValue[],
+    body: endpoint.sampleBody ?? "",
+  }
+}
+
+export function ApiTester() {
+  const [state, setState] = useState(() => buildInitialState(testableEndpoints[0].id))
+  const [result, setResult] = useState<ResponseResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [history, setHistory] = useState<HistoryEntry[]>([])
+
+  const lockedPathKeys = useMemo(
+    () => (state.endpoint.params ?? []).filter((p) => p.location === "path").map((p) => p.name),
+    [state.endpoint],
+  )
+  const lockedQueryKeys = useMemo(
+    () =>
+      (state.endpoint.params ?? [])
+        .filter((p) => p.location === "query" && p.required)
+        .map((p) => p.name),
+    [state.endpoint],
+  )
+
+  const bodyDisabled = state.endpoint.method === "GET" || state.endpoint.method === "DELETE"
+
+  const selectEndpoint = (id: string) => {
+    setState(buildInitialState(id))
+    setResult(null)
+  }
+
+  const handleSend = async () => {
+    setLoading(true)
+    try {
+      const response = await sendRequest({
+        method: state.endpoint.method,
+        path: state.endpoint.path,
+        pathParams: state.pathParams,
+        queryParams: state.queryParams,
+        headers: state.headers,
+        body: state.body,
+      })
+      setResult(response)
+      setHistory((prev) => [
+        {
+          id: `${Date.now()}`,
+          method: state.endpoint.method,
+          url: response.requestUrl,
+          status: response.status,
+          durationMs: response.durationMs,
+          timestamp: response.timestamp,
+        },
+        ...prev,
+      ].slice(0, 20))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <div className="flex flex-col gap-5">
+        <EndpointPicker selectedId={state.endpoint.id} onSelect={selectEndpoint} />
+
+        <Card>
+          <CardContent className="flex flex-col gap-2 p-4">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className={cn("w-16 justify-center font-mono text-xs", methodStyles[state.endpoint.method])}>
+                {state.endpoint.method}
+              </Badge>
+              <code className="min-w-0 flex-1 truncate font-mono text-sm">{state.endpoint.path}</code>
+            </div>
+          </CardContent>
+        </Card>
+
+        {state.pathParams.length > 0 && (
+          <KeyValueEditor
+            title="Path parameters"
+            rows={state.pathParams}
+            onChange={(rows) => setState((s) => ({ ...s, pathParams: rows }))}
+            lockedKeys={lockedPathKeys}
+          />
+        )}
+
+        <KeyValueEditor
+          title="Query parameters"
+          rows={state.queryParams}
+          onChange={(rows) => setState((s) => ({ ...s, queryParams: rows }))}
+          lockedKeys={lockedQueryKeys}
+        />
+
+        <KeyValueEditor
+          title="Headers"
+          rows={state.headers}
+          onChange={(rows) => setState((s) => ({ ...s, headers: rows }))}
+          keyPlaceholder="Header-Name"
+        />
+
+        <BodyEditor
+          value={state.body}
+          onChange={(body) => setState((s) => ({ ...s, body }))}
+          disabled={bodyDisabled}
+        />
+
+        <Button onClick={handleSend} disabled={loading} className="gap-2 self-start">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          Send request
+        </Button>
+
+        <HistoryPanel
+          entries={history}
+          onClear={() => setHistory([])}
+          onSelect={(entry) => {
+            const match = testableEndpoints.find((e) => e.method === entry.method && entry.url.includes(e.path.split("{")[0]))
+            if (match) selectEndpoint(match.id)
+          }}
+        />
+      </div>
+
+      <div className="lg:sticky lg:top-20 lg:self-start">
+        <ResponseViewer result={result} loading={loading} />
+      </div>
+    </div>
+  )
+}

--- a/features/api-test/components/body-editor.tsx
+++ b/features/api-test/components/body-editor.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useMemo } from "react"
+import { AlertCircle, CheckCircle2 } from "lucide-react"
+
+import { Textarea } from "@/components/ui/textarea"
+
+interface BodyEditorProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+export function BodyEditor({ value, onChange, disabled }: BodyEditorProps) {
+  const validation = useMemo(() => {
+    if (!value.trim()) return { valid: true, message: null as string | null }
+    try {
+      JSON.parse(value)
+      return { valid: true, message: "Valid JSON" }
+    } catch (error) {
+      return { valid: false, message: error instanceof Error ? error.message : "Invalid JSON" }
+    }
+  }, [value])
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">Body</label>
+        {value.trim() && (
+          <span
+            className={`flex items-center gap-1 text-xs ${validation.valid ? "text-emerald-500" : "text-destructive"}`}
+          >
+            {validation.valid ? <CheckCircle2 className="h-3 w-3" /> : <AlertCircle className="h-3 w-3" />}
+            {validation.message}
+          </span>
+        )}
+      </div>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={disabled ? "This method does not send a body." : '{\n  "key": "value"\n}'}
+        className="min-h-[180px] resize-y font-mono text-xs"
+        spellCheck={false}
+      />
+    </div>
+  )
+}

--- a/features/api-test/components/endpoint-picker.tsx
+++ b/features/api-test/components/endpoint-picker.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import { groupEndpoints, testableEndpoints, type HttpMethod } from "@/features/api-test/lib/endpoints"
+
+interface EndpointPickerProps {
+  selectedId: string
+  onSelect: (id: string) => void
+}
+
+const methodStyles: Record<HttpMethod, string> = {
+  GET: "text-emerald-500",
+  POST: "text-blue-500",
+  DELETE: "text-red-500",
+}
+
+export function EndpointPicker({ selectedId, onSelect }: EndpointPickerProps) {
+  const grouped = groupEndpoints()
+  const selected = testableEndpoints.find((endpoint) => endpoint.id === selectedId)
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium">Endpoint</label>
+      <Select value={selectedId} onValueChange={onSelect}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Choose an endpoint" />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.entries(grouped).map(([group, endpoints]) => (
+            <SelectGroup key={group}>
+              <SelectLabel>{group}</SelectLabel>
+              {endpoints.map((endpoint) => (
+                <SelectItem key={endpoint.id} value={endpoint.id}>
+                  <span className={cn("font-mono text-xs font-semibold", methodStyles[endpoint.method])}>
+                    {endpoint.method}
+                  </span>{" "}
+                  {endpoint.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          ))}
+        </SelectContent>
+      </Select>
+      {selected?.auth && (
+        <Badge variant="secondary" className="w-fit text-[10px]">
+          Requires a signed-in session
+        </Badge>
+      )}
+    </div>
+  )
+}

--- a/features/api-test/components/history-panel.tsx
+++ b/features/api-test/components/history-panel.tsx
@@ -7,12 +7,12 @@ import { cn } from "@/lib/utils"
 import type { HttpMethod } from "@/features/api-test/lib/endpoints"
 
 export interface HistoryEntry {
-  id        : string
-  method    : HttpMethod | string
-  url       : string
-  status    : number
+  id: string
+  method: HttpMethod | string
+  url: string
+  status: number
   durationMs: number
-  timestamp : string
+  timestamp: string
 }
 
 interface HistoryPanelProps {

--- a/features/api-test/components/history-panel.tsx
+++ b/features/api-test/components/history-panel.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import type { HttpMethod } from "@/features/api-test/lib/endpoints"
+
+export interface HistoryEntry {
+  id        : string
+  method    : HttpMethod | string
+  url       : string
+  status    : number
+  durationMs: number
+  timestamp : string
+}
+
+interface HistoryPanelProps {
+  entries: HistoryEntry[]
+  onSelect: (entry: HistoryEntry) => void
+  onClear: () => void
+}
+
+function statusColor(status: number): string {
+  if (status === 0) return "text-red-500"
+  if (status < 300) return "text-emerald-500"
+  if (status < 400) return "text-blue-500"
+  if (status < 500) return "text-amber-500"
+  return "text-red-500"
+}
+
+export function HistoryPanel({ entries, onSelect, onClear }: HistoryPanelProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">History</span>
+        {entries.length > 0 && (
+          <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={onClear}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">Requests you send will appear here.</p>
+      ) : (
+        <ScrollArea className="max-h-[220px]">
+          <div className="flex flex-col gap-1">
+            {entries.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => onSelect(entry)}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted"
+              >
+                <Badge variant="outline" className="w-14 shrink-0 justify-center font-mono text-[10px]">
+                  {entry.method}
+                </Badge>
+                <span className="min-w-0 flex-1 truncate font-mono">{entry.url}</span>
+                <span className={cn("shrink-0 font-mono", statusColor(entry.status))}>{entry.status || "ERR"}</span>
+              </button>
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  )
+}

--- a/features/api-test/components/key-value-editor.tsx
+++ b/features/api-test/components/key-value-editor.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { Plus, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { KeyValue } from "@/features/api-test/lib/request-runner"
+
+interface KeyValueEditorProps {
+  title: string
+  rows: KeyValue[]
+  onChange: (rows: KeyValue[]) => void
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+  lockedKeys?: string[] // keys that cannot be renamed or removed (e.g. required path/query params)
+}
+
+export function KeyValueEditor({
+  title,
+  rows,
+  onChange,
+  keyPlaceholder = "key",
+  valuePlaceholder = "value",
+  lockedKeys = [],
+}: KeyValueEditorProps) {
+  const updateRow = (index: number, field: keyof KeyValue, value: string) => {
+    const next = [...rows]
+    next[index] = { ...next[index], [field]: value }
+    onChange(next)
+  }
+
+  const addRow = () => onChange([...rows, { key: "", value: "" }])
+  const removeRow = (index: number) => onChange(rows.filter((_, i) => i !== index))
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">{title}</label>
+        <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={addRow}>
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {rows.length === 0 && <p className="text-xs text-muted-foreground">None set.</p>}
+
+      <div className="flex flex-col gap-2">
+        {rows.map((row, index) => {
+          const locked = lockedKeys.includes(row.key)
+          return (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                value={row.key}
+                placeholder={keyPlaceholder}
+                disabled={locked}
+                onChange={(e) => updateRow(index, "key", e.target.value)}
+                className="font-mono text-xs"
+              />
+              <Input
+                value={row.value}
+                placeholder={valuePlaceholder}
+                onChange={(e) => updateRow(index, "value", e.target.value)}
+                className="font-mono text-xs"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                onClick={() => removeRow(index)}
+                disabled={locked}
+                aria-label="Remove row"
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/features/api-test/components/response-viewer.tsx
+++ b/features/api-test/components/response-viewer.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
+import type { ResponseResult } from "@/features/api-test/lib/request-runner"
+
+interface ResponseViewerProps {
+  result: ResponseResult | null
+  loading: boolean
+}
+
+function statusColor(status: number): string {
+  if (status === 0) return "text-red-500 border-red-500/30 bg-red-500/10"
+  if (status < 300) return "text-emerald-500 border-emerald-500/30 bg-emerald-500/10"
+  if (status < 400) return "text-blue-500 border-blue-500/30 bg-blue-500/10"
+  if (status < 500) return "text-amber-500 border-amber-500/30 bg-amber-500/10"
+  return "text-red-500 border-red-500/30 bg-red-500/10"
+}
+
+export function ResponseViewer({ result, loading }: ResponseViewerProps) {
+  const [copied, setCopied] = useState(false)
+
+  const copyBody = async () => {
+    if (!result) return
+    try {
+      await navigator.clipboard.writeText(result.body)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Failed to copy response:", err)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full min-h-[300px] items-center justify-center rounded-lg border text-sm text-muted-foreground">
+        Sending request…
+      </div>
+    )
+  }
+
+  if (!result) {
+    return (
+      <div className="flex h-full min-h-[300px] items-center justify-center rounded-lg border text-sm text-muted-foreground">
+        Send a request to see the response here.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-3 rounded-lg border p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className={cn("font-mono text-xs", statusColor(result.status))}>
+          {result.status || "ERR"} {result.statusText}
+        </Badge>
+        <span className="text-xs text-muted-foreground">{result.durationMs} ms</span>
+        <span className="truncate text-xs text-muted-foreground">{result.requestUrl}</span>
+      </div>
+
+      {result.error && (
+        <p className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{result.error}</p>
+      )}
+
+      {result.status === 401 && (
+        <p className="rounded-md bg-amber-500/10 px-3 py-2 text-xs text-amber-600">
+          401 Unauthorized — this endpoint requires a signed-in session. Sign in and try again.
+        </p>
+      )}
+
+      <Tabs defaultValue="body" className="flex flex-1 flex-col">
+        <div className="flex items-center justify-between">
+          <TabsList>
+            <TabsTrigger value="body">Body</TabsTrigger>
+            <TabsTrigger value="headers">Headers ({Object.keys(result.headers).length})</TabsTrigger>
+          </TabsList>
+          <Button variant="ghost" size="sm" className="h-7 gap-1.5 px-2 text-xs" onClick={copyBody}>
+            {copied ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
+
+        <TabsContent value="body" className="mt-2 flex-1">
+          <ScrollArea className="h-[320px] rounded-md border bg-[#1e1e1e]">
+            <pre className="whitespace-pre-wrap break-all p-3 font-mono text-xs text-zinc-200">
+              {result.body || "(empty response body)"}
+            </pre>
+          </ScrollArea>
+        </TabsContent>
+
+        <TabsContent value="headers" className="mt-2 flex-1">
+          <ScrollArea className="h-[320px] rounded-md border">
+            <div className="flex flex-col divide-y">
+              {Object.entries(result.headers).map(([key, value]) => (
+                <div key={key} className="flex gap-3 px-3 py-2 text-xs">
+                  <span className="w-40 shrink-0 font-mono font-medium">{key}</span>
+                  <span className="min-w-0 flex-1 break-all font-mono text-muted-foreground">{value}</span>
+                </div>
+              ))}
+              {Object.keys(result.headers).length === 0 && (
+                <p className="px-3 py-2 text-xs text-muted-foreground">No headers returned.</p>
+              )}
+            </div>
+          </ScrollArea>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/features/api-test/lib/endpoints.ts
+++ b/features/api-test/lib/endpoints.ts
@@ -1,0 +1,149 @@
+export type HttpMethod = "GET" | "POST" | "DELETE"
+export type ParamLocation = "query" | "body" | "path"
+
+export interface EndpointParam {
+  name: string
+  location: ParamLocation
+  required: boolean
+  placeholder?: string
+}
+
+export interface TestableEndpoint {
+  id: string
+  method: HttpMethod
+  path: string // may contain {param} placeholders
+  label: string
+  group: string
+  auth: boolean
+  params?: EndpointParam[]
+  sampleBody?: string // pretty-printed JSON string used to prefill the body editor
+}
+
+export const testableEndpoints: TestableEndpoint[] = [
+  {
+    id: "chat-send",
+    method: "POST",
+    path: "/api/chat",
+    label: "Send chat message",
+    group: "AI Chat",
+    auth: false,
+    sampleBody: `{
+  "message": "How do I center a div with flexbox?",
+  "history": []
+}`,
+  },
+  {
+    id: "chat-enhance",
+    method: "POST",
+    path: "/api/chat",
+    label: "Enhance prompt",
+    group: "AI Chat",
+    auth: false,
+    sampleBody: `{
+  "action": "enhance",
+  "prompt": "fix my code"
+}`,
+  },
+  {
+    id: "chat-health",
+    method: "GET",
+    path: "/api/chat",
+    label: "Chat health check",
+    group: "AI Chat",
+    auth: false,
+  },
+  {
+    id: "code-suggestion",
+    method: "POST",
+    path: "/api/code-suggestion",
+    label: "Get code suggestion",
+    group: "Code Suggestions",
+    auth: false,
+    sampleBody: `{
+  "fileContent": "function add(a, b) {\\n  \\n}",
+  "cursorLine": 1,
+  "cursorColumn": 2,
+  "suggestionType": "completion",
+  "fileName": "math.ts"
+}`,
+  },
+  {
+    id: "github-connect-get",
+    method: "GET",
+    path: "/api/github/connect",
+    label: "List connected repositories",
+    group: "GitHub Integration",
+    auth: true,
+  },
+  {
+    id: "github-connect-post",
+    method: "POST",
+    path: "/api/github/connect",
+    label: "Connect a repository",
+    group: "GitHub Integration",
+    auth: true,
+    sampleBody: `{
+  "repoId": "123456",
+  "repoName": "xynraco",
+  "fullName": "abdhullah200/Xynraco",
+  "owner": "abdhullah200",
+  "url": "https://github.com/abdhullah200/Xynraco",
+  "cloneUrl": "https://github.com/abdhullah200/Xynraco.git"
+}`,
+  },
+  {
+    id: "github-connect-delete",
+    method: "DELETE",
+    path: "/api/github/connect",
+    label: "Disconnect a repository",
+    group: "GitHub Integration",
+    auth: true,
+    params: [{ name: "repoId", location: "query", required: true, placeholder: "123456" }],
+  },
+  {
+    id: "github-repositories",
+    method: "GET",
+    path: "/api/github/repositories",
+    label: "List GitHub repositories",
+    group: "GitHub Integration",
+    auth: true,
+  },
+  {
+    id: "github-repo-contents",
+    method: "GET",
+    path: "/api/github/repo-contents",
+    label: "Get repository contents",
+    group: "GitHub Integration",
+    auth: true,
+    params: [
+      { name: "repoId", location: "query", required: true, placeholder: "123456" },
+      { name: "path", location: "query", required: false, placeholder: "src" },
+    ],
+  },
+  {
+    id: "github-repo-tree",
+    method: "GET",
+    path: "/api/github/repo-tree",
+    label: "Get full repository tree",
+    group: "GitHub Integration",
+    auth: true,
+    params: [{ name: "repoId", location: "query", required: true, placeholder: "123456" }],
+  },
+  {
+    id: "template-load",
+    method: "GET",
+    path: "/api/template/{id}",
+    label: "Load playground template",
+    group: "Template Loader",
+    auth: false,
+    params: [{ name: "id", location: "path", required: true, placeholder: "playground_id" }],
+  },
+]
+
+export function groupEndpoints(): Record<string, TestableEndpoint[]> {
+  return testableEndpoints.reduce<Record<string, TestableEndpoint[]>>((acc, endpoint) => {
+    acc[endpoint.group] = acc[endpoint.group] ?? []
+    acc[endpoint.group].push(endpoint)
+    return acc
+  }, {})
+}

--- a/features/api-test/lib/request-runner.ts
+++ b/features/api-test/lib/request-runner.ts
@@ -1,0 +1,105 @@
+export interface KeyValue {
+  key: string
+  value: string
+}
+
+export interface SendRequestInput {
+  method: string
+  path: string // may contain {param} placeholders
+  pathParams: KeyValue[]
+  queryParams: KeyValue[]
+  headers: KeyValue[]
+  body?: string
+}
+
+export interface ResponseResult {
+  ok: boolean
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  body: string
+  durationMs: number
+  timestamp: string
+  requestUrl: string
+  error?: string
+}
+
+export function buildUrl(path: string, pathParams: KeyValue[], queryParams: KeyValue[]): string {
+  let resolvedPath = path
+  for (const { key, value } of pathParams) {
+    if (!key) continue
+    resolvedPath = resolvedPath.replace(`{${key}}`, encodeURIComponent(value))
+  }
+
+  const url = new URL(resolvedPath, window.location.origin)
+  for (const { key, value } of queryParams) {
+    if (!key) continue
+    url.searchParams.set(key, value)
+  }
+
+  return url.toString()
+}
+
+export async function sendRequest(input: SendRequestInput): Promise<ResponseResult> {
+  const requestUrl = buildUrl(input.path, input.pathParams, input.queryParams)
+
+  const headers: Record<string, string> = {}
+  for (const { key, value } of input.headers) {
+    if (key) headers[key] = value
+  }
+
+  const hasBody = input.method !== "GET" && input.method !== "DELETE" && input.body?.trim()
+  if (hasBody && !headers["Content-Type"]) {
+    headers["Content-Type"] = "application/json"
+  }
+
+  const startedAt = performance.now()
+  const timestamp = new Date().toISOString()
+
+  try {
+    const response = await fetch(requestUrl, {
+      method: input.method,
+      headers,
+      body: hasBody ? input.body : undefined,
+      credentials: "same-origin",
+    })
+
+    const durationMs = Math.round(performance.now() - startedAt)
+    const responseHeaders: Record<string, string> = {}
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value
+    })
+
+    const rawText = await response.text()
+    let body = rawText
+    try {
+      body = JSON.stringify(JSON.parse(rawText), null, 2)
+    } catch {
+      // not JSON, leave as raw text
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+      body,
+      durationMs,
+      timestamp,
+      requestUrl,
+    }
+  } catch (error) {
+    const durationMs = Math.round(performance.now() - startedAt)
+    return {
+      ok: false,
+      status: 0,
+      statusText: "Network Error",
+      headers: {},
+      body: "",
+      durationMs,
+      timestamp,
+      requestUrl,
+      error: error instanceof Error ? error.message : "Unknown network error",
+    }
+  }
+}

--- a/features/dashboard/components/dashboard-sidebar.tsx
+++ b/features/dashboard/components/dashboard-sidebar.tsx
@@ -62,6 +62,7 @@ const lucideIconMap: Record<string, LucideIcon> = {
 
 // Starter template types
 const STARTER_TEMPLATES = ["REACT", "NEXTJS", "EXPRESS", "VUE", "HONO", "ANGULAR"];
+const API_TEST_ROUTE = "/api-test"
 
 export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundData: PlaygroundData[] }) {
   const pathname = usePathname()
@@ -69,6 +70,14 @@ export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundD
   const [isModalOpen, setIsModalOpen] = useState(false)
   
   const recentPlaygrounds = initialPlaygroundData.slice(0, 5) // Show last 5 recent items
+
+  const getPlaygroundHref = (playground: PlaygroundData) => {
+    if (playground.name === "API Prototype" || playground.id === "pg-1") {
+      return API_TEST_ROUTE
+    }
+
+    return `/playground/${playground.id}`
+  }
 
   const handleCreatePlayground = async (data: {
     title: string;
@@ -146,14 +155,15 @@ export function DashboardSidebar({ initialPlaygroundData }: { initialPlaygroundD
                 <>
                   {recentPlaygrounds.map((playground) => {
                     const IconComponent = lucideIconMap[playground.icon] || Code2;
+                    const href = getPlaygroundHref(playground)
                     return (
                       <SidebarMenuItem key={playground.id}>
                         <SidebarMenuButton
                           asChild
-                          isActive={pathname === `/playground/${playground.id}`}
+                          isActive={pathname === href}
                           tooltip={playground.name}
                         >
-                          <Link href={`/playground/${playground.id}`}>
+                          <Link href={href}>
                             {IconComponent && <IconComponent className="h-4 w-4" />}
                             <span>{playground.name}</span>
                           </Link>

--- a/features/home/compontents/header.tsx
+++ b/features/home/compontents/header.tsx
@@ -42,7 +42,7 @@ export function Header() {
                       Docs
                     </Link>
                     <Link
-                      href="/api-info"
+                      href="/api-test"
                       className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors flex items-center gap-2"
                     >
                       API
@@ -69,7 +69,7 @@ export function Header() {
                     Docs
                   </Link>
                   <Link
-                    href="/api-info"
+                    href="/api-test"
                     className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
                   >
                     API

--- a/routes.ts
+++ b/routes.ts
@@ -1,4 +1,4 @@
-export const publicRoutes: string[] = ["/docs", "/api-info"];
+export const publicRoutes: string[] = ["/docs", "/api-test"];
 
 export const protectedRoutes: string[] = ["/"];
 


### PR DESCRIPTION
This pull request introduces a new interactive "API Tester" workspace, replacing the old placeholder API page and providing a full-featured UI for sending and inspecting API requests. It adds a suite of new client components for endpoint selection, request editing, history tracking, and response viewing, and links the new tester from the dashboard.

**New API Tester Workspace**

- **Feature implementation:**
  - Added a new `ApiTester` component and supporting UI components (`body-editor`, `endpoint-picker`, `key-value-editor`, `history-panel`, `response-viewer`) to provide a complete interface for building and sending requests to the Xynraco API, including endpoint selection, parameter editing, and live response inspection. [[1]](diffhunk://#diff-dc8fa39995edf0315e76b628800c3339d03a6eea30f5bf21cc06be2ea506554bR1-R160) [[2]](diffhunk://#diff-b9ccd9f87fa3f65502e9346359cdf5c3dad73b6a8abcfee011294bd12985818cR1-R48) [[3]](diffhunk://#diff-94ce83136ca57b3692948cd7856e7d6ed3cbc79132cf892c87bf2ca28af0e36aR1-R53) [[4]](diffhunk://#diff-049a9fdffa61b0cb022690750179fe1d9d3ad042fed029ee07aef9d6e87fe517R1-R81) [[5]](diffhunk://#diff-4f9929fce0388fc8c8a9260ed37dc82b4cfffc3b6b1fc49ab211facfcc76a00cR1-R68) [[6]](diffhunk://#diff-946036a0a6a022c1f503583eacf209267099e864ea89a29ce4a288c109e9615cR1-R114)
  - The API tester tracks request history, validates JSON bodies, and displays formatted responses with status, headers, and body, including copy-to-clipboard support. [[1]](diffhunk://#diff-dc8fa39995edf0315e76b628800c3339d03a6eea30f5bf21cc06be2ea506554bR1-R160) [[2]](diffhunk://#diff-b9ccd9f87fa3f65502e9346359cdf5c3dad73b6a8abcfee011294bd12985818cR1-R48) [[3]](diffhunk://#diff-4f9929fce0388fc8c8a9260ed37dc82b4cfffc3b6b1fc49ab211facfcc76a00cR1-R68) [[4]](diffhunk://#diff-946036a0a6a022c1f503583eacf209267099e864ea89a29ce4a288c109e9615cR1-R114)

**Dashboard and Navigation Updates**

- **Dashboard integration:**
  - Added a prominent "API Tester" card to the dashboard page, linking to the new `/api-test` workspace and marking it as "New".
  - Adjusted dashboard layout to accommodate the new card and maintain consistent sizing.

**Page and Routing Changes**

- **Page updates:**
  - Removed the old placeholder `API` page and replaced it with the new API Tester page at `/api-test`. [[1]](diffhunk://#diff-73dade4a0ad95c941e985a8987ff9c68349407964ee3f01d9feb8d27c06f5eeeL1-L8) [[2]](diffhunk://#diff-17e16f3d1fe7efede8d8314e59f8c96c2ce2d66d8186920485730870108c12d8R1-R25)

These changes collectively provide users with a powerful tool to interactively test and debug API endpoints directly from the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API Tester page for sending requests to supported endpoints.
  * Added tools for editing parameters, headers, and JSON request bodies.
  * Added response details, status information, headers, copy support, and request history.
  * Added API Tester access from the dashboard, sidebar, and site navigation.

* **Improvements**
  * Updated API navigation to point to the new API Tester experience.
  * Adjusted dashboard layout and spacing for the new entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->